### PR TITLE
logger->die: wrong method and context

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name = App-SpamcupNG
-version = 0.019
+version = 0.020
 author = Alceu Rodrigues de Freitas Junior <glasswalk3r@yahoo.com.br>
 license = GPL_3
 copyright_holder = Alceu Rodrigues de Freitas Junior

--- a/lib/App/SpamcupNG.pm
+++ b/lib/App/SpamcupNG.pm
@@ -404,7 +404,7 @@ sub main_loop {
 
         foreach my $error ( @{$errors_ref} ) {
             if ( $error->is_fatal() ) {
-                $logger->die( $error->message() );
+                $logger->fatal( $error->message() );
 
                 # must stop processing the HTML for this report and move to next
                 return 0;


### PR DESCRIPTION
The correct method is `logdie`, not `die`.
Also, fatal is the correct method, because the can be skipped and the execution flow just jumps to the next SPAM.